### PR TITLE
changed function call to fix compile error

### DIFF
--- a/javalibusb1/src/main/c/usbw.c
+++ b/javalibusb1/src/main/c/usbw.c
@@ -122,7 +122,7 @@ uint8_t usbw_get_device_address(struct libusb_device *device) {
 
 enum libusb_speed usbw_get_speed(struct libusb_device *device) {
     usbw_printf("PRE: %s(%p)\n", __func__, device);
-    enum libusb_speed speed = libusb_get_speed(device);
+    enum libusb_speed speed = libusb_get_device_speed(device);
     usbw_printf("RET: %s: speed=%u\n", __func__, speed);
     return speed;
 }


### PR DESCRIPTION
Hi,

I've just tried to install your library with libusb-1.0.9 and I think a function name has changed since you wrote it.  The change in this pull request updates it to the new name.

Alex
